### PR TITLE
Add mapping rule for ros1_bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,7 @@ rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files})
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()
+
+install(
+  FILES mapping_rules.yaml
+  DESTINATION share/${PROJECT_NAME})

--- a/mapping_rules.yaml
+++ b/mapping_rules.yaml
@@ -1,0 +1,4 @@
+- ros1_package_name: 'uuid_msgs'
+  ros1_message_name: 'UniqueID'
+  ros2_package_name: 'unique_identifier_msgs'
+  ros2_message_name: 'UUID'

--- a/package.xml
+++ b/package.xml
@@ -17,11 +17,12 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
-  
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>
+    <ros1_bridge mapping_rules="mapping_rules.yaml"/>
   </export>
 
 </package>


### PR DESCRIPTION
Allows the UUID message to be transferred across ros1_bridge