### PR TITLE
Enable linter tests on unique_identifier_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files})
 
 ament_export_dependencies(rosidl_default_runtime)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 
 install(

--- a/package.xml
+++ b/package.xml
@@ -8,9 +8,9 @@
     ROS messages for universally unique identifiers.
   </description>
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
-  <author>Jack O'Quin</author>
   <license>BSD</license>
   <url>http://ros.org/wiki/unique_identifier_msgs</url>
+  <author>Jack O'Quin</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,9 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
Enable linters on the package aiming to increase package quality level to 1.

Changed author tag position in manifest file to pass linter test.