### PR TITLE
Change Contributing.md to match linter template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 Any contribution that you make to this repository will
-be under the BSD 3-Clause License as declared in the [LICENSE file](LICENSE).
+be under the 3-Clause BSD License, as dictated by that
+[license](https://opensource.org/licenses/BSD-3-Clause).
 
 Contributors must sign-off each commit by adding a `Signed-off-by: ...`
 line to commit messages to certify that they have the right to submit


### PR DESCRIPTION
As the title says, the `CONTRIBUTING.md` will match the template used for other packages within ROS2 core.

This will fix test failures caused by [ament_lint#247](https://github.com/ament/ament_lint/pull/247).

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>