### PR TITLE
Add dependency to std_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,13 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
 
 set(msg_files
   "msg/UUID.msg"
 )
 
-rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files})
+rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files} DEPENDENCIES std_msgs)
 
 ament_export_dependencies(rosidl_default_runtime)
 

--- a/package.xml
+++ b/package.xml
@@ -12,11 +12,14 @@
   <url>http://ros.org/wiki/unique_identifier_msgs</url>
   <author>Jack O'Quin</author>
 
+  <build_depend>std_msgs</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
The dependency to std_msgs was missing in package.xml and CMakeLists.txt. This led to problems in our build system (yocto using on meta-ros, where dependencies are auto-generated from package.xml).

Following other packages in common_interfaces, I added std_msgs both to package.xml and CMakeLists.txt.

Relevant lines from sensor_msgs in common_interfaces:
https://github.com/ros2/common_interfaces/blob/3ee382893da4c34b43cf836d4c235d25ab4befab/sensor_msgs/package.xml#L16
https://github.com/ros2/common_interfaces/blob/3ee382893da4c34b43cf836d4c235d25ab4befab/sensor_msgs/package.xml#L21
https://github.com/ros2/common_interfaces/blob/3ee382893da4c34b43cf836d4c235d25ab4befab/sensor_msgs/CMakeLists.txt#L17
https://github.com/ros2/common_interfaces/blob/3ee382893da4c34b43cf836d4c235d25ab4befab/sensor_msgs/CMakeLists.txt#L54

This should be relevant for multiple branches.

Signed-off-by: Johannes Schrimpf <johannes.schrimpf@blueye.no>