### PR TITLE
Depend on rosidl_core instead of rosidl_defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
+# Depend on "core" generators instead of "default" generators
+# because ROS actions depend on this package
+find_package(rosidl_core_generators REQUIRED)
 
 set(msg_files
   "msg/UUID.msg"
@@ -20,7 +22,7 @@ set(msg_files
 
 rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files})
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_core_runtime)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -89,7 +89,7 @@ Results of the nightly linter tests can be found [here](http://build.ros2.org/vi
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `unique_identifier_msgs` has the following runtime ROS dependency, which is **Quality Level 1**:
-* `rosidl_default_runtime` [QUALITY DECLARATION](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+* `rosidl_core_runtime` [QUALITY DECLARATION](https://github.com/ros2/rosidl_core/tree/master/rosidl_core_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 
@@ -104,7 +104,6 @@ It has several "buildtool" dependencies, which do not affect the resulting quali
 Currently nightly results can be seen here:
 * [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/unique_identifier_msgs/)
 * [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/unique_identifier_msgs/)
-* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/unique_identifier_msgs/)
 * [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/unique_identifier_msgs/)
 
 # Security [7]

--- a/package.xml
+++ b/package.xml
@@ -15,9 +15,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_core_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This allows us to forward a dependency on action_msgs for users and avoid a dependency cycle.

Connected to https://github.com/ros2/rosidl_defaults/pull/22