### PR TITLE
patch for mapping uuid via `ros1_bridge`

### DIFF
--- a/mapping_rules.yaml
+++ b/mapping_rules.yaml
@@ -2,3 +2,5 @@
   ros1_message_name: 'UniqueID'
   ros2_package_name: 'unique_identifier_msgs'
   ros2_message_name: 'UUID'
+  fields_1_to_2:
+    uuid: 'uuid'


### PR DESCRIPTION
I'm providing this patch pr on behalf of my colleagues @hoffmann-stefan and @loyvanbeek
They might have more details than me...

we have observed an inconsistency when bridging `unique_identifier_msgs` via `ros1_bridge`
in our opiniton this is not a bug in the `ros1_bridge` but adding the additional mapping rules it the actual proper fix for the behavior observed

the pr is targeting `foxy` as we are using that branch
maybe we can find a common solution to this and have it deployed to `foxy` and later

---

# Steps to reproduce

Bridge `/test_id` topic of type `uuid_msgs/UniqueID`/`unique_identifier_msgs/msg/UUID` via `ros1_bridge` `parameter_bridge`.

run the following commands:
```
source_amr_ros1 && rostopic pub /test_id uuid_msgs/UniqueID "uuid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]"
```
```
source_amr_ros2 && ros2 topic pub /test_id unique_identifier_msgs/msg/UUID "uuid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2]"
```

```
source_amr_ros1 && rostopic echo /test_id
```

```
source_amr_ros2 && ros2 topic echo /test_id
```

Both echo commands should print uuids with either 1 or 2 at the end. But the bridge without the workaround outputs the uuids from the other side with only zeros.
